### PR TITLE
If given as raw ability scores, auto compute modifiers.

### DIFF
--- a/CardGenerator.py
+++ b/CardGenerator.py
@@ -825,6 +825,8 @@ class MonsterCardLayout(CardLayout):
             self.wisdom,
             self.charisma,
         ]
+        # if modifiers are (int), e.g. 13, then automatically reformat as "13 (+1)"
+        modifiers = [(m if isinstance(m, str) else "%d (%+d)" % (m, math.floor((m-10)/2))) for m in modifiers]
         modifier_table_data = [
             [
                 Paragraph(a, self.fonts.paragraph_styles["modifier_title"])


### PR DESCRIPTION
I find it redundant to specify ability scores and modifiers in the yaml file. Might be able to compute one from the other.