### PR TITLE
Explicitly format image path as relative to yaml file

### DIFF
--- a/CardGenerator.py
+++ b/CardGenerator.py
@@ -1062,7 +1062,7 @@ if __name__ == "__main__":
                 entry["title"],
                 entry["subtitle"],
                 entry.get("artist", None),
-                entry["image_path"],
+                os.path.dirname(args.input) + "/" + entry["image_path"],
                 entry["armor_class"],
                 entry["max_hit_points"],
                 entry["speed"],


### PR DESCRIPTION
This is not a good solution yet but one to discuss. Currently the paths are all relative to the working folder, not the yaml file. So if my cards are in multiple places, I can either run the script from the folder where it finds the fonts, or from the folder where it finds the images. I found this patch to be sufficient for my needs but it is not a clean solution. The same should go for the paths to the bundles resources.