### PR TITLE
Draft: add an option for print bleed

### DIFF
--- a/CardGenerator.py
+++ b/CardGenerator.py
@@ -265,28 +265,6 @@ class Border(IntEnum):
     TOP = 3
 
 
-class Modifier(object):
-    @classmethod
-    def from_ability_score(cls, value):
-        if value < 1 or value > 30:
-            raise ValueError("Ability scores must be between 1 and 30 inclusive")
-        return cls(math.floor((value - 10) / 2))
-
-    def __init__(self, value):
-        value = int(value)
-        if value < -5 or value > 10:
-            raise ValueError(
-                "Ability score modifiers must be between -5 and +10 inclusive"
-            )
-        self.value = value
-
-    def __str__(self):
-        if self.value <= 0:
-            return "+{}".format(self.value)
-        else:
-            return "-{}".format(self.value)
-
-
 class TemplateTooSmall(Exception):
     pass
 

--- a/CardGenerator.py
+++ b/CardGenerator.py
@@ -344,12 +344,8 @@ class CardLayout(ABC):
                     break
 
                 # Caluclate how much space is left
-                available_height = (
-                    current_frame._y
-                    - current_frame._y1p
-                    # - self.elements[0].getSpaceBefore()
-                )
                 available_width = current_frame._getAvailableWidth()
+                available_height = current_frame._y - current_frame._y1p
 
                 # Calculate how much heigh is required for the line and the next element
                 _, line_height = element.wrap(available_width, 0xFFFFFFFF)
@@ -716,7 +712,6 @@ class MonsterCardLayout(CardLayout):
         canvas.drawString(*self.source_location, self.source)
 
     def fill_frames(self, canvas):
-
         top_stats = [
             [
                 Paragraph(
@@ -859,7 +854,7 @@ class MonsterCardLayout(CardLayout):
             title = Paragraph(
                 "LEGENDARY ACTIONS", self.fonts.paragraph_styles["action_title"]
             )
-            first_legnedary = True
+            first_legendary = True
             for entry in self.legendary or []:
                 if type(entry) == str:
                     paragraph = Paragraph(
@@ -876,9 +871,9 @@ class MonsterCardLayout(CardLayout):
                         'Legendary action cannot be type "{}"'.format(type(entry))
                     )
 
-                if first_legnedary:
+                if first_legendary:
                     element = KeepTogether([title, paragraph])
-                    first_legnedary = False
+                    first_legendary = False
                 else:
                     element = paragraph
                 self.elements.append(element)
@@ -917,7 +912,6 @@ class MonsterCardSuperEpic(SuperEpicCard, MonsterCardLarge):
 
 
 class CardGenerator(ABC):
-
     sizes = []  # Set by subclass
 
     def __init__(self, *args, **kwargs):

--- a/CardGenerator.py
+++ b/CardGenerator.py
@@ -274,6 +274,7 @@ class CardLayout(ABC):
     BACKGROUND_CORNER_DIAMETER = 2 * mm
     LOGO_WIDTH = 42 * mm
     STANDARD_BORDER = 2.5 * mm
+    STANDARD_MARGIN = 1.0 * mm
     TEXT_MARGIN = 2 * mm
     BASE_WIDTH = 63 * mm
     BASE_HEIGHT = 89 * mm
@@ -296,7 +297,7 @@ class CardLayout(ABC):
         fonts=FreeFonts(),
     ):
         self.frames = []
-        self.FRONT_MARGINS = tuple([x + 1 * mm for x in self.BORDER_FRONT])
+        self.FRONT_MARGINS = tuple([x + self.STANDARD_MARGIN for x in self.BORDER_FRONT])
 
         self.title = title
         self.subtitle = subtitle

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ optional arguments:
                         Output file path
   -f {free,accurate}, --fonts {free,accurate}
                         What fonts to use when generating cards
+  -b radius, --bleed radius
+                        How many millimeters to extend the card border.
 ```
 Included in the `example` directory is an example YAML file that generates a `Goblin` card.
 


### PR DESCRIPTION
So this is the last modification I did before printing my extra cards. An option to add a 1mm print bleed radius to the cards.

This patch is super ugly and I need some feedback how to properly modify it, if you want to add this feature:

1) There are two paths adding the bleed: a) via `WIDTH`, `HEIGHT`, and `BORDER_*` or b) via `BLEED` in every drawing command. Option a) is a more minimalistic solution but comes with problem 2). Option b) is ugly, but more flexible.
2) When modifying WIDTH and HEIGHT, the subclasses depend on the values of the superclass, and the constructor in the superclass reads the values overridden in the subclass. Thus I cannot move the initialisation of the `WIDTH` and `HEIGHT` to `__init__`. I solved it now like this: the argument parser runs first, then the classes are defined, then the `if __name__ == '__main__'` comes duplicated to execute the logic in the classes.
3) There is a TODO in the code that says that cards are just over-printed instead of discarded when space runs out and the next larger template is selected. This becomes noticeable with print bleed because front+back of a small card are then wider by 2*bleed than the next large card. This needs to be solved for this feature to work.
4) I chose to drop the class `Modifier` since it is unused, but this does not really belong to this feature, I can revert the change.

Now, about 1) and 2), maybe you have a better idea?